### PR TITLE
Replace OSGetTime RNG usage with CubeRandom

### DIFF
--- a/payload/game/OnlineTimer.cc
+++ b/payload/game/OnlineTimer.cc
@@ -2,9 +2,7 @@
 
 #include "game/Kart2DCommon.hh"
 
-extern "C" {
-#include <dolphin/OSTime.h>
-}
+#include <payload/crypto/CubeRandom.hh>
 #include <portable/Array.hh>
 
 void OnlineTimer::init(u32 duration) {
@@ -20,7 +18,7 @@ void OnlineTimer::calc() {
     u32 milliseconds = m_frame * 1000 / 60;
     if (m_frame != 0 && m_frame != m_duration) {
         u32 nextMilliseconds = (m_frame + 1) * 1000 / 60;
-        milliseconds += OSGetTime() % (nextMilliseconds - milliseconds);
+        milliseconds += CubeRandom::Instance()->get(nextMilliseconds - milliseconds);
     }
     u32 seconds = milliseconds / 1000;
     milliseconds %= 1000;

--- a/payload/game/SceneCharacterSelect.cc
+++ b/payload/game/SceneCharacterSelect.cc
@@ -14,11 +14,11 @@
 
 extern "C" {
 #include <dolphin/GXTransform.h>
-#include <dolphin/OSTime.h>
 }
 #include <jsystem/J2DAnmLoaderDataBase.hh>
 #include <jsystem/J2DOrthoGraph.hh>
 #include <jsystem/JKRExpHeap.hh>
+#include <payload/crypto/CubeRandom.hh>
 #include <portable/Algorithm.hh>
 #include <portable/Align.hh>
 
@@ -773,9 +773,10 @@ void SceneCharacterSelect::stateSpin() {
 
     m_characterIndices.fill(CharacterID::Count);
     u32 flags = 0;
+    CubeRandom *random = CubeRandom::Instance();
     for (u32 i = 0; i < m_statusCount; i++) {
         for (u32 j = 0; j < 2; j++) {
-            u32 characterIndex = OSGetTime() % (CharacterID::Count - (i * 2 + j));
+            u32 characterIndex = random->get(CharacterID::Count - (i * 2 + j));
             for (u32 k = 0; k < CharacterID::Count && k <= characterIndex; k++) {
                 characterIndex += flags >> k & 1;
             }

--- a/payload/game/SceneCoursePoll.cc
+++ b/payload/game/SceneCoursePoll.cc
@@ -11,12 +11,10 @@
 #include "game/SequenceInfo.hh"
 #include "game/System.hh"
 
-extern "C" {
-#include <dolphin/OSTime.h>
-}
 #include <jsystem/J2DAnmLoaderDataBase.hh>
 #include <payload/CourseManager.hh>
 #include <payload/Lock.hh>
+#include <payload/crypto/CubeRandom.hh>
 
 SceneCoursePoll::SceneCoursePoll(JKRArchive *archive, JKRHeap *heap)
     : Scene(archive, heap), m_heap(heap) {
@@ -124,10 +122,11 @@ void SceneCoursePoll::draw() {
 void SceneCoursePoll::calc() {
     Kart2DCommon *kart2DCommon = Kart2DCommon::Instance();
     if (m_nameCount < m_playerCount) {
-        if (OSGetTime() % 30 == m_nameCount % 30) {
+        CubeRandom *random = CubeRandom::Instance();
+        if (random->get(30) == m_nameCount % 30) {
             J2DScreen &screen = m_courseScreens[m_nameCount];
             kart2DCommon->changeUnicodeTexture("ABC", 3, screen, "PName0");
-            if (OSGetTime() / 30 % 2) {
+            if (random->get(2) == 0) {
                 kart2DCommon->changeUnicodeTexture("DEF", 3, screen, "PName1");
                 m_playerNameAnmTransformFrames[m_nameCount] = 0;
             } else {
@@ -143,7 +142,7 @@ void SceneCoursePoll::calc() {
             }
             if (m_nameCount == 1) {
                 Lock<Mutex> lock(m_mutex);
-                m_courseIndices[m_nameCount] = OSGetTime() % m_courseCount;
+                m_courseIndices[m_nameCount] = random->get(m_courseCount);
                 refreshCourses();
             }
             m_nameCount++;
@@ -151,7 +150,7 @@ void SceneCoursePoll::calc() {
                 Lock<Mutex> lock(m_mutex);
                 for (u32 i = 0; i < m_playerCount; i++) {
                     if (m_courseIndices[i] >= m_courseCount) {
-                        m_courseIndices[i] = OSGetTime() % m_courseCount;
+                        m_courseIndices[i] = random->get(m_courseCount);
                     }
                 }
                 refreshCourses();
@@ -359,7 +358,7 @@ void SceneCoursePoll::stateSpin() {
     m_spinFrame++;
     if (m_spinFrame < 180) {
         if (m_spinFrame % 5 == 0) {
-            m_playerIndex = OSGetTime() % m_playerCount;
+            m_playerIndex = CubeRandom::Instance()->get(m_playerCount);
             GameAudio::Main::Instance()->startSystemSe(SoundID::JA_SE_TR_CURSOL);
         }
     } else {

--- a/payload/game/SceneMapSelect.cc
+++ b/payload/game/SceneMapSelect.cc
@@ -15,13 +15,11 @@
 #include "game/System.hh"
 #include "game/SystemRecord.hh"
 
-extern "C" {
-#include <dolphin/OSTime.h>
-}
 #include <jsystem/J2DAnmLoaderDataBase.hh>
 #include <jsystem/J2DPicture.hh>
 #include <payload/CourseManager.hh>
 #include <payload/Lock.hh>
+#include <payload/crypto/CubeRandom.hh>
 #include <portable/Algorithm.hh>
 
 SceneMapSelect::SceneMapSelect(JKRArchive *archive, JKRHeap *heap)
@@ -646,10 +644,11 @@ void SceneMapSelect::stateNextScene() {
 }
 
 void SceneMapSelect::refreshSpin() {
-    m_spinMapIndex = OSGetTime() % m_mapCount;
+    CubeRandom *random = CubeRandom::Instance();
+    m_spinMapIndex = random->get(m_mapCount);
     m_spinRowIndex = m_spinMapIndex / 3;
     if (m_spinRowIndex > 0) {
-        m_spinRowIndex -= OSGetTime() % 2;
+        m_spinRowIndex -= random->get(2);
     }
     if (m_rowCount >= 2 && m_spinRowIndex == m_rowCount - 1) {
         m_spinRowIndex--;

--- a/payload/game/ScenePersonalRoom.cc
+++ b/payload/game/ScenePersonalRoom.cc
@@ -12,11 +12,9 @@
 #include "game/SequenceApp.hh"
 #include "game/SequenceInfo.hh"
 
-extern "C" {
-#include <dolphin/OSTime.h>
-}
 #include <jsystem/J2DAnmLoaderDataBase.hh>
 #include <payload/CourseManager.hh>
+#include <payload/crypto/CubeRandom.hh>
 
 extern "C" {
 #include <stdio.h>
@@ -159,8 +157,9 @@ ScenePersonalRoom::~ScenePersonalRoom() {}
 
 void ScenePersonalRoom::init() {
     m_charCount = 20;
+    CubeRandom *random = CubeRandom::Instance();
     for (u32 i = 0; i < m_charCount; i++) {
-        m_chars[i] = OSGetTime() % 8;
+        m_chars[i] = random->get(8);
     }
     m_revealCode = false;
     m_optionCount = 0;

--- a/payload/game/ScenePlayerList.cc
+++ b/payload/game/ScenePlayerList.cc
@@ -11,10 +11,8 @@
 #include "game/SequenceApp.hh"
 #include "game/System.hh"
 
-extern "C" {
-#include <dolphin/OSTime.h>
-}
 #include <jsystem/J2DAnmLoaderDataBase.hh>
+#include <payload/crypto/CubeRandom.hh>
 
 extern "C" {
 #include <stdio.h>
@@ -95,6 +93,7 @@ void ScenePlayerList::calc() {
 
 void ScenePlayerList::slideIn() {
     Kart2DCommon *kart2DCommon = Kart2DCommon::Instance();
+    CubeRandom *random = CubeRandom::Instance();
     for (u32 i = 0; i < m_playerScreens.count(); i++) {
         J2DScreen &screen = m_playerScreens[i];
         GXColor color = Race2D::GetPlayerNumberColor(i);
@@ -127,7 +126,7 @@ void ScenePlayerList::slideIn() {
         for (u32 j = 0; j < pictures.count(); j++) {
             pictures[j] = screen.search("MMR%u", j)->downcast<J2DPicture>();
         }
-        s32 mmr = OSGetTime() % 10000;
+        s32 mmr = random->get(10000);
         kart2DCommon->changeNumberTexture(mmr, pictures.values(), pictures.count(), false, false);
     }
 

--- a/payload/game/SceneTitle.cc
+++ b/payload/game/SceneTitle.cc
@@ -14,13 +14,11 @@
 #include "game/System.hh"
 
 #include <cube/Console.hh>
-extern "C" {
-#include <dolphin/OSTime.h>
-}
 #include <jsystem/J2DAnmLoaderDataBase.hh>
 #include <jsystem/J2DPicture.hh>
 #include <payload/CourseManager.hh>
 #include <payload/MemoryProtection.hh>
+#include <payload/crypto/CubeRandom.hh>
 #include <payload/online/Client.hh>
 #include <payload/online/CubeServerManager.hh>
 
@@ -268,7 +266,7 @@ void SceneTitle::stateIdle() {
                 raceInfo.settingForWaitDemo(s_demoType == 3);
                 u32 packIndex = 0;
                 u32 courseCount = courseManager->raceCourseCount(packIndex);
-                u32 courseIndex = OSGetTime() % courseCount;
+                u32 courseIndex = CubeRandom::Instance()->get(courseCount);
                 const CourseManager::Course &course =
                         courseManager->raceCourse(packIndex, courseIndex);
                 u32 courseOrder = raceInfo.getConsoleCount() < 2 ? 2 : 1;

--- a/payload/jsystem/JASAramStream.cc
+++ b/payload/jsystem/JASAramStream.cc
@@ -5,9 +5,9 @@
 
 extern "C" {
 #include <dolphin/DVD.h>
-#include <dolphin/OSTime.h>
 }
 #include <payload/Lock.hh>
+#include <payload/crypto/CubeRandom.hh>
 #include <portable/Bytes.hh>
 extern "C" {
 #include <stdio.h>
@@ -203,8 +203,9 @@ bool JASAramStream::openFile(s32 entrynum) {
     if (length >= 0 && static_cast<size_t>(length) < dirPath.count()) {
         Storage::DirHandle dir(dirPath.values());
         Storage::NodeInfo nodeInfo;
+        CubeRandom *random = CubeRandom::Instance();
         for (u32 bestScore = 0; dir.read(nodeInfo);) {
-            u32 score = OSGetTime() % 1024;
+            u32 score = random->get(1024);
             if (score >= bestScore) {
                 name = nodeInfo.name;
                 bestScore = score;


### PR DESCRIPTION
Closes #223.

I took the liberty of replacing an `OSGetTime() % 30 / 2` expression with a more simple `random->get(2) == 0` in SceneCoursePoll.