### PR TITLE
Document DI

### DIFF
--- a/channel/DI.cc
+++ b/channel/DI.cc
@@ -3,6 +3,12 @@
 #include <cube/Clock.hh>
 #include <cube/DCache.hh>
 #include <cube/Platform.hh>
+#include <portable/Align.hh>
+#include <portable/Log.hh>
+
+extern "C" {
+#include <assert.h>
+}
 
 extern "C" volatile u32 disr;
 extern "C" volatile u32 dicvr;
@@ -20,43 +26,76 @@ extern "C" volatile u32 gpio_out;
 extern "C" volatile u32 resets;
 
 bool DI::ReadDiscID() {
-    disr = 0x54;
-    dicmdbuf0 = 0xa8000040;
+    ClearInterrupts();
+
+    // Input: adjusted offset in dicmdbuf1, size in dicmdbuf2, buffer in dimar, size in dilength
+    // Output: void
+    MakeCommand(0xa8, 0x0, 0x40);
     dicmdbuf1 = 0x0;
     dicmdbuf2 = 0x20;
     dimar = 0x80000000 & 0x1fffffff;
     dilength = 0x20;
-    dicr = 0x3;
+    SendCommand(true);
 
-    while (dicr & 0x1) {}
+    WaitForCommand();
 
     DCache::Invalidate(reinterpret_cast<void *>(0x80000000), 0x20);
-    return !(disr & 0x4);
+    return !IsDeviceError();
 }
 
 bool DI::Read(void *dst, u32 size, u32 offset) {
-    disr = 0x54;
-    dicmdbuf0 = 0xa8000000;
+    assert(IsAligned(dst, 0x20));
+    assert(IsAligned(size, 0x20));
+    ClearInterrupts();
+
+    // Input: adjusted offset in dicmdbuf1, size in dicmdbuf2, buffer in dimar, size in dilength
+    // Output: void
+    MakeCommand(0xa8, 0x0, 0x0);
     dicmdbuf1 = offset >> 2;
     dicmdbuf2 = size;
     dimar = reinterpret_cast<uintptr_t>(dst) & 0x1fffffff;
     dilength = size;
-    dicr = 0x3;
+    SendCommand(true);
 
-    while (dicr & 0x1) {}
+    WaitForCommand();
 
     DCache::Invalidate(dst, size);
-    return !(disr & 0x4);
+    return !IsDeviceError();
 }
 
 bool DI::IsInserted() {
-    dicmdbuf0 = 0xe0000000;
+    // Input: void
+    // Output: error code in diimmbuf
+    MakeCommand(0xe0, 0x0, 0x0);
     diimmbuf = 0x0;
-    dicr = 0x1;
+    SendCommand(false);
 
-    while (dicr & 0x1) {}
+    WaitForCommand();
 
-    return !(diimmbuf & 0x1000000);
+    u8 category = diimmbuf >> 24;
+    switch (category) {
+    case 5:
+        ERROR("DI::IsInserted() called before DI was initialized!");
+        return false;
+    case 1:
+    case 3:
+        return false;
+    default:
+        return true;
+    }
+}
+
+bool DI::IsInitialized() {
+    // Input: void
+    // Output: error code in diimmbuf
+    MakeCommand(0xe0, 0x0, 0x0);
+    diimmbuf = 0x0;
+    SendCommand(false);
+
+    WaitForCommand();
+
+    u8 category = diimmbuf >> 24;
+    return category != 5;
 }
 
 void DI::Reset() {
@@ -70,4 +109,24 @@ void DI::Reset() {
         Clock::WaitMilliseconds(1);
         resets |= 0x400;
     }
+}
+
+void DI::ClearInterrupts() {
+    disr = 0x54;
+}
+
+void DI::MakeCommand(u8 command, u8 sub0, u16 sub1) {
+    dicmdbuf0 = command << 24 | sub0 << 16 | sub1;
+}
+
+void DI::SendCommand(bool dma) {
+    dicr = 0x1 | dma << 1;
+}
+
+void DI::WaitForCommand() {
+    while (dicr & 0x1) {}
+}
+
+bool DI::IsDeviceError() {
+    return disr & 0x4;
 }

--- a/channel/DI.hh
+++ b/channel/DI.hh
@@ -4,11 +4,44 @@
 
 class DI {
 public:
+    // Reads the disc ID for use with DiscID and initializes the drive
+    // Returns true if success, false if error
     static bool ReadDiscID();
+
+    // Reads from disc into the destination buffer
+    // Returns true if success, false if error
     static bool Read(void *dst, u32 size, u32 offset);
+
+    // Checks if the disc is inserted into the console
+    // Prints an error if the drive is not initialized
+    // Returns true if ok, false if not inserted or initialized
     static bool IsInserted();
+
+    // Checks if the drive is initialized
+    // Returns true if initialized, false if not
+    static bool IsInitialized();
+
+    // Resets and deinitializes the drive
     static void Reset();
 
 private:
+    // Clears all interrupts in disr
+    // This should be called first if applicable, as it fully overwrites the disr
+    static void ClearInterrupts();
+
+    // Makes a command for dicmdbuf0
+    static void MakeCommand(u8 command, u8 sub0, u16 sub1);
+
+    // Sends the command to the drive
+    // The dma arg is false for immediate mode, true for DMA mode
+    static void SendCommand(bool dma);
+
+    // Waits for a command to finish
+    static void WaitForCommand();
+
+    // This should only be called after WaitForCommand finishes
+    // Returns whether or not a device error occured during command execution
+    static bool IsDeviceError();
+
     DI();
 };


### PR DESCRIPTION
Pending more rigorous testing. This should help with DI maintenance in the future.

I added some additional logic to help clarify an edgecase where a disc is not considered to be inserted if the drive is not initialized. `DI::IsInitialized` is added to delineate the two cases if necessary. Currently, the behavior is to error if we attempt to query whether or not a disc is inserted before it's initialized, but this can be adjusted with a default parameter if needed.